### PR TITLE
Sharpen homepage positioning and expand site nav

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -13,8 +13,10 @@
 	<div class="collapse navbar-collapse" id="navbar-collapse-1">
 	  <ul class="nav navbar-nav navbar-right">
 		<li><a href="{{ site.url }}{{ site.baseurl }}/">Home</a></li>
-		<li><a href="{{ site.url }}{{ site.baseurl }}/team">Team</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/research">Research</a></li>
 		<li><a href="{{ site.url }}{{ site.baseurl }}/publications">Publications</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/allnews.html">News</a></li>
+		<li><a href="{{ site.url }}{{ site.baseurl }}/team">Team</a></li>
 		<li><a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Scholar</a></li>
 	  </ul>
 	</div>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -11,7 +11,7 @@ permalink: /
     <p class="eyebrow">LLMs · Agents · Reasoning · Safety</p>
     <h1>Wenxiang Jiao <span>焦文祥</span></h1>
     <p class="hero-lede">
-      Researcher building evaluations, agents, and alignment methods for more reliable large language models.
+      I build benchmarks, agents, and alignment methods that expose where large language models break — in reasoning, safety, and psychological behavior — and turn the findings into systems that ship.
     </p>
     <div class="hero-meta">
       <span>LLM Application Algorithm Expert, Xiaohongshu</span>
@@ -38,6 +38,9 @@ permalink: /
   <div class="section-body">
     <p>
       My work studies how large language models reason, act, refuse unsafe requests, and portray psychological traits. I turn these questions into benchmarks, open-source systems, and training techniques for robust AI applications.
+    </p>
+    <p>
+      At Xiaohongshu I lead LLM application algorithms — taking research on agents, reasoning, and safety, and turning it into models and systems that serve hundreds of millions of users. I continue to publish and collaborate with academic groups in NLP and AI.
     </p>
     <div class="compact-list">
       <div><strong>Current</strong><span>Xiaohongshu Inc., LLM Application Algorithm Expert, 2025 - Present</span></div>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,46 +1,49 @@
 ---
-title: "Allan Lab - Research"
+title: "Wenxiang Jiao (焦文祥) - Research"
 layout: textlay
-excerpt: "Allan Lab -- Research"
+excerpt: "Research directions of Wenxiang Jiao: LLM agents, reasoning, safety, and psychology."
 sitemap: false
 permalink: /research/
 ---
 
 # Research
 
-Our overarching goal is to explore and understand new quantum states of electronic matter on the atomic scale. To do so, we use and develop novel spectroscopic-imaging scanning tunneling microscopy (SI-STM) tools to visualize the relevant quantum mechanical degrees of freedom.
+My work studies how large language models reason, act, refuse unsafe requests, and portray psychological traits. I turn these questions into benchmarks, open-source systems, and training techniques for more reliable AI applications.
 
-Our goal is to build instruments and develop techniques that enable us to address the questions we find most interesting. This is possible thanks also to Milan's broad background with different research themes and technologies: he learned his trade in [Seamus Davis’ SI-STM lab](http://davisgroup.lassp.cornell.edu/) and with [Felix Baumberger](http://dpmc.unige.ch/gr_baumberger/index.html), and later moved as an [ETH fellow](http://www.ethfellows.ethz.ch/) to [Andreas Wallraff’s qudev lab](http://www.qudev.ethz.ch/) where he investigated coupled cavity arrays in circuit QED. We further have group members with different background and interests, working together on physics and instrumentation.
+Four directions currently drive most of my research:
 
-Here are some themes and techniques that we currently work on:
+---
 
-**Scanning tunneling noise spectroscopy (STNS).** We have developed a novel cryogenic MHz amplifier that allows us to measure not only the average tunneling current, but also its fluctuation! This has many applications: one can detect the fluctuations of the electronic states, peculiar tunneling processes, and shot noise. We have used this instrument to discover charge trapping in the insulating layer of the cuprates, connected to the c-axis mystery, and to measure the doubling of the charge due to Andreev processes to the superfluid in a lead sample.
+## General Agents
 
+Building agents that perceive multiple modalities, use tools at scale, and collaborate with other agents to solve complex, long-horizon tasks.
 
-**Mott physics and high-temperature superconductivity.** Questions of interest include: (i), How does the Mott state collapse upon doping and how is this related to the complex phase diagram of high-temperature superconductors? (ii), What is the strange metal phase seen in correlated electron systems? Is this an exotic long-range entangled state? What is the mechanism of dissipation in that state? (iii), Why is the transition temperature in high-temperature superconductors so high? We have worked on iridates, rhodates, and cuprates.
+- **DeepAgent** — a general reasoning agent that searches and composes tools from large-scale toolsets ([WWW 2026](https://arxiv.org/abs/2510.21618), [code](https://github.com/DeepExperience/DeepAgent)).
+- **OmniGAIA** — a benchmark for omni-modal general AI assistants.
+- **Multi-Agent Debate (MAD)** — eliciting divergent reasoning through structured agent interaction ([EMNLP 2024](https://arxiv.org/abs/2305.19118), [code](https://github.com/Skytliang/Multi-Agents-Debate)).
 
-**Nanofabricated "Smart Tips"**.
-![]({{ site.url }}{{ site.baseurl }}/images/respic/SmartTip.png){: style="width: 250px; float: left; margin: 0px  10px"}
-One of the  projects back from my job-proposal is to develop nanofabricated STM tips. The idea behind these “smart tips” is to use the technologies that were developed over decades in nanofabrication and make them available for scanning probe by using a nano-device instead of the traditional STM tungsten tip. One gains the flexibility of using different functionalities that are known from the fields of nanofabrication and mesoscopic physics. We are collaborating with the group Simon Groeblacher at TU Delft to realize this concept, benefitting from their unparalleled micro/nano fabrication know how.  A prototype of a smart tip is shown to the left. See publications in Microsyst Nanoeng, Nanotechnology, and PRB.
+## LLM Reasoning
 
-**Josephson STM.** Josephson STM has the ability to gain insight into spatial variations of the order parameter, or superfluid density. We have managed to, for the first time, use JSTM with atomic resolution on a quantum material.
-We have used atomic-resolution Josephson scanning tunneling microscopy to reveal a strongly inhomogeneous superfluid in the iron-based superconductor FeTe0.55Se0.45. The results and their implications are published in Nature.
+Pushing the frontier of mathematical, reflective, and long-chain reasoning while keeping inference efficient.
 
-We also detected and investigated a quite particular YSR state in the same material.
+- **REA-RL** — reinforcement learning recipes for reasoning-efficient LLMs (ICLR 2026).
+- **DeepCompress** — compressing long chains of thought without losing accuracy (ICLR 2026).
 
-**Ultra-stable SI-STM instrument.**  ![]({{ site.url }}{{ site.baseurl }}/images/respic/STMHead.png){: style="width: 250px; float: right; margin: 0px 10px"}
-For SI-STM, having the most stable STM head is key. We have used finite element simulations, good choices in material science, and craftsmanship to build the most stable STM head in the world, to our knowledge. See publication in RSI.
+## LLM Safety
 
+Risk awareness, jailbreak robustness, multilingual safety, and refusal behavior.
 
-**Strange Metals.** The strange metal phase might be the most mysterious phase of high-temperature superconductors. Here, the electrical resistivity grows linearly with temperature T in large areas of the phase diagram, with a mean free path that diminishes to a fraction of the interatomic distance. T-linear resistivity is often associated with quantum critical points and marginal-Fermi-liquid physics. In strange metals, the mystery seems to go even further: we deal with something that looks like a quantum critical phase over an extended range of the phase diagram instead of cumulating in a point. There exists no consistent theory for strange metals, leading to more adventurous new approaches including the holographic theories that use insights from quantum gravity to explain strange metals (a recent textbook on this was written by our colleagues at Leiden University, Schalm and Zaanen).
-We are part of the 'Strange Metal consortium NL' that includes the groups of Hussey, Golden, van Heumen, Zaanen, Schalm, Stoof and Vandoren. 
+- **CipherChat** — studying how safety alignment generalizes (or fails) on cipher-based non-natural languages ([ICLR 2024](https://arxiv.org/abs/2308.06463), [project](https://llmcipherchat.github.io/)).
+- **DeRTa** — improving refusal training so models decline unsafe requests without over-refusing benign ones.
 
-**Magnetic fluctuations and electron spin resonance.**
-![]({{ site.url }}{{ site.baseurl }}/images/respic/SpinFluc.png){: style="width: 70%; float: center; margin: 10px"}
+## LLM Personality
 
-**Twisted bilayer graphene and other material with super-periodicities.**
-We have proposed that artificial super-periodicities can lead to improved superconductivity, both because of increased density of states and because of phase space arguments (see image from our SciPost publication below). Perhaps for different reasons, twisted bilayer graphene has been shown to superconduct! We are investigate this material with the groups of Efetov, Baumberger, and van der Molen.
+Treating conversational AI as a subject of psychological measurement: emotion, personality, relationships, and motivations.
 
-![]({{ site.url }}{{ site.baseurl }}/images/respic/SciPost.png){: style="width: 70%; float: center; margin: 0px"}
+- **PsychoBench / PPBench** — evaluating the psychological portrayal of LLMs ([ICLR 2024 Oral](https://arxiv.org/abs/2310.01386), [code](https://github.com/CUHK-ARISE/PsychoBench)).
+- **EmotionBench** — measuring how LLMs respond under emotionally charged scenarios.
+- **Fints** — fine-grained interpretation of LLMs' affective and personality traits.
 
-### ... and more.
+---
+
+For a chronological list of all papers, see [Publications]({{ site.url }}{{ site.baseurl }}/publications/) or my [Google Scholar](https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate) page.


### PR DESCRIPTION
- Rewrite /research/ to cover the four LLM directions (agents, reasoning, safety, personality) with representative works, replacing the leftover Allan Lab template.
- Tighten the homepage hero lede and add an About paragraph clarifying the Xiaohongshu role.
- Expose Research and News in the top navigation.