### PR TITLE
Refine homepage layout: merge work sections, reorder, semantic tags

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,5 +35,3 @@ kramdown:
   enable_coderay: false
   parse_block_html: true # default for kramdown is false. This will enable using Markdown links
 
-
-theme: jekyll-theme-cayman

--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -2,40 +2,44 @@
   url: https://github.com/RUC-NLPIR/OmniGAIA
   repo: RUC-NLPIR/OmniGAIA
   venue: ArXiv 2026
-  tone: red
+  tone: preprint
   description: A benchmark for evaluating omni-modal general AI assistants.
 
 - name: DeepAgent
   url: https://github.com/RUC-NLPIR/DeepAgent
   repo: RUC-NLPIR/DeepAgent
   venue: WWW 2026
-  tone: green
+  tone: conf
+  paper: https://arxiv.org/abs/2510.21618
   description: A general reasoning agent with scalable toolsets for complex multi-step tasks.
 
 - name: Multi-Agent Debate
   url: https://github.com/Skytliang/Multi-Agents-Debate
   repo: Skytliang/Multi-Agents-Debate
   venue: EMNLP 2024
-  tone: blue
+  tone: conf
+  paper: https://arxiv.org/abs/2305.19118
   description: A framework for encouraging divergent thinking in LLMs through structured debate.
 
 - name: CipherChat
   url: https://github.com/RobustNLP/CipherChat
   repo: RobustNLP/CipherChat
   venue: ICLR 2024
-  tone: red
+  tone: conf
+  paper: https://arxiv.org/abs/2308.06463
   description: A safety evaluation framework for stealthy chat with LLMs via cipher encoding.
 
 - name: PsychoBench
   url: https://github.com/CUHK-ARISE/PsychoBench
   repo: CUHK-ARISE/PsychoBench
   venue: ICLR 2024 Oral
-  tone: green
+  tone: oral
+  paper: https://arxiv.org/abs/2310.01386
   description: A benchmark for evaluating psychological portrayals in large language models.
 
 - name: Is ChatGPT A Good Translator
   url: https://github.com/wxjiao/Is-ChatGPT-A-Good-Translator
   repo: wxjiao/Is-ChatGPT-A-Good-Translator
   venue: ArXiv 2023
-  tone: blue
+  tone: preprint
   description: A systematic evaluation of ChatGPT translation across languages and domains.

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,21 +1,15 @@
 <footer id="footer" class="site-footer">
   <div class="container-fluid">
-    <div class="footer-grid">
-      <div>
+    <div class="footer-grid footer-grid-compact">
+      <div class="footer-brand">
         <strong>Wenxiang Jiao</strong>
-        <p>LLM Algorithm Expert at Xiaohongshu. Research in large language models, AI agents, reasoning, safety, and LLM psychology.</p>
+        <p>&copy; {{ site.time | date: '%Y' }}</p>
       </div>
-      <div>
-        <strong>Contact</strong>
-        <p><a href="mailto:wenxiangjiaonju@gmail.com">wenxiangjiaonju@gmail.com</a></p>
-      </div>
-      <div>
-        <strong>Links</strong>
-        <p>
-          <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>
-          <a href="https://github.com/wxjiao">GitHub</a>
-          <a href="https://twitter.com/WenxiangJiao">X / Twitter</a>
-        </p>
+      <div class="footer-links">
+        <a href="mailto:wenxiangjiaonju@gmail.com">Email</a>
+        <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Scholar</a>
+        <a href="https://github.com/wxjiao">GitHub</a>
+        <a href="https://twitter.com/WenxiangJiao">X / Twitter</a>
       </div>
     </div>
   </div>

--- a/_includes/spotlight-projects.html
+++ b/_includes/spotlight-projects.html
@@ -4,11 +4,15 @@
     <div class="project-card-top">
       <a class="project-name" href="{{ project.url }}">{{ project.name }}</a>
       <a class="project-badge" href="{{ project.url }}" aria-label="{{ project.name }} GitHub stars">
-        <img src="https://img.shields.io/github/stars/{{ project.repo }}?label=Stars&style=flat&color=2563eb&labelColor=eff6ff" alt="GitHub stars for {{ project.name }}">
+        <img loading="lazy" src="https://img.shields.io/github/stars/{{ project.repo }}?label=&style=flat&color=2563eb&labelColor=eff6ff" alt="GitHub stars for {{ project.name }}">
       </a>
     </div>
     <span class="project-tag project-tag-{{ project.tone }}">{{ project.venue }}</span>
     <p>{{ project.description }}</p>
+    <div class="inline-links project-links">
+      {% if project.paper %}<a href="{{ project.paper }}">Paper</a>{% endif %}
+      <a href="{{ project.url }}">Code</a>
+    </div>
   </article>
   {% endfor %}
 </div>

--- a/_pages/home.md
+++ b/_pages/home.md
@@ -43,9 +43,44 @@ permalink: /
       <div><strong>Current</strong><span>Xiaohongshu Inc., LLM Algorithm Expert, 2025 - Present</span></div>
       <div><strong>Previously</strong><span>Tencent AI Lab, Senior Researcher, 2021 - 2025</span></div>
       <div><strong>Education</strong><span>Ph.D., The Chinese University of Hong Kong, 2021</span></div>
-      <div><strong>Service</strong><span>Reviewer for Nature, Nature Machine Intelligence, NeurIPS, ICML, and ACL</span></div>
+      <div class="service-row">
+        <strong>Service</strong>
+        <span class="service-venues">
+          <span class="venue-label">Reviewer for</span>
+          <span class="venue-chip">Nature</span>
+          <span class="venue-chip">Nature Machine Intelligence</span>
+          <span class="venue-chip">NeurIPS</span>
+          <span class="venue-chip">ICML</span>
+          <span class="venue-chip">ACL</span>
+        </span>
+      </div>
     </div>
   </div>
+</section>
+
+<section markdown="0" class="section-block latest-news">
+  <div class="section-heading">
+    <p class="eyebrow">Updates</p>
+    <h2>Latest News</h2>
+  </div>
+  <div class="news-list">
+    {% for article in site.data.news limit:5 %}
+    <article class="news-item">
+      <time>{{ article.date }}</time>
+      <p>{{ article.headline }}</p>
+    </article>
+    {% endfor %}
+  </div>
+  <p class="section-link"><a href="{{ site.url }}{{ site.baseurl }}/allnews.html">Read all news</a></p>
+</section>
+
+<section markdown="0" class="section-block">
+  <div class="section-heading">
+    <p class="eyebrow">Selected Work</p>
+    <h2>Highlighted Work</h2>
+  </div>
+  {% include spotlight-projects.html %}
+  <p class="section-link"><a href="{{ site.url }}{{ site.baseurl }}/publications/">View all publications</a></p>
 </section>
 
 <section markdown="0" class="section-block research-areas">
@@ -75,82 +110,4 @@ permalink: /
       <span>PsychoBench · EmotionBench · Fints</span>
     </article>
   </div>
-</section>
-
-<section markdown="0" class="section-block selected-publications">
-  <div class="section-heading">
-    <p class="eyebrow">Selected Work</p>
-    <h2>Selected Publications</h2>
-  </div>
-  <div class="publication-list">
-    <article class="publication-row">
-      <div class="publication-meta">WWW 2026</div>
-      <div class="publication-main">
-        <h3>DeepAgent: A General Reasoning Agent with Scalable Toolsets</h3>
-        <p>A general reasoning agent that searches for and uses tools from large-scale toolsets.</p>
-        <div class="inline-links">
-          <a href="https://arxiv.org/abs/2510.21618">Paper</a>
-          <a href="https://github.com/DeepExperience/DeepAgent">Code</a>
-        </div>
-      </div>
-    </article>
-    <article class="publication-row">
-      <div class="publication-meta">ICLR 2024 Oral</div>
-      <div class="publication-main">
-        <h3>On the Humanity of Conversational AI: Evaluating the Psychological Portrayal of LLMs</h3>
-        <p>PPBench evaluates personality, relationships, motivations, and emotional abilities in LLMs.</p>
-        <div class="inline-links">
-          <a href="https://arxiv.org/abs/2310.01386">Paper</a>
-          <a href="https://github.com/CUHK-ARISE/PsychoBench">Code</a>
-        </div>
-      </div>
-    </article>
-    <article class="publication-row">
-      <div class="publication-meta">ICLR 2024</div>
-      <div class="publication-main">
-        <h3>GPT-4 Is Too Smart To Be Safe: Stealthy Chat with LLMs via Cipher</h3>
-        <p>CipherChat studies how safety alignment generalizes to cipher-based non-natural languages.</p>
-        <div class="inline-links">
-          <a href="https://arxiv.org/abs/2308.06463">Paper</a>
-          <a href="https://llmcipherchat.github.io/">Project</a>
-        </div>
-      </div>
-    </article>
-    <article class="publication-row">
-      <div class="publication-meta">EMNLP 2024</div>
-      <div class="publication-main">
-        <h3>Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate</h3>
-        <p>Multi-Agent Debate explores divergent chains of thought through structured agent interaction.</p>
-        <div class="inline-links">
-          <a href="https://arxiv.org/abs/2305.19118">Paper</a>
-          <a href="https://github.com/Skytliang/Multi-Agents-Debate">Code</a>
-        </div>
-      </div>
-    </article>
-  </div>
-  <p class="section-link"><a href="{{ site.url }}{{ site.baseurl }}/publications/">View all publications</a></p>
-</section>
-
-<section markdown="0" class="section-block">
-  <div class="section-heading">
-    <p class="eyebrow">Open Source</p>
-    <h2>Spotlight Projects</h2>
-  </div>
-  {% include spotlight-projects.html %}
-</section>
-
-<section markdown="0" class="section-block latest-news">
-  <div class="section-heading">
-    <p class="eyebrow">Updates</p>
-    <h2>Latest News</h2>
-  </div>
-  <div class="news-list">
-    {% for article in site.data.news limit:5 %}
-    <article class="news-item">
-      <time>{{ article.date }}</time>
-      <p>{{ article.headline }}</p>
-    </article>
-    {% endfor %}
-  </div>
-  <p class="section-link"><a href="{{ site.url }}{{ site.baseurl }}/allnews.html">Read all news</a></p>
 </section>

--- a/css/main.scss
+++ b/css/main.scss
@@ -360,19 +360,70 @@ img {
   font-weight: 800;
 }
 
-.project-tag-blue {
+.project-tag-conf {
   background: #eff6ff;
   color: #1d4ed8;
 }
 
-.project-tag-green {
-  background: #ecfdf5;
-  color: var(--green);
+.project-tag-oral {
+  background: #fff8e1;
+  color: #92590b;
+  box-shadow: inset 0 0 0 1px #f4cf66;
 }
 
-.project-tag-red {
-  background: #fef2f2;
-  color: var(--red);
+.project-tag-oral::before {
+  content: "★ ";
+  margin-right: 2px;
+}
+
+.project-tag-preprint {
+  background: transparent;
+  color: var(--muted);
+  box-shadow: inset 0 0 0 1px var(--line);
+}
+
+.project-tag-workshop {
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.project-links {
+  margin-top: 12px;
+}
+
+.project-links a {
+  min-height: 28px;
+  padding: 3px 9px;
+  font-size: 12px;
+}
+
+.service-row {
+  align-items: start !important;
+}
+
+.service-venues {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+}
+
+.service-venues .venue-label {
+  color: var(--muted);
+  margin-right: 2px;
+}
+
+.service-venues .venue-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  background: var(--soft);
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
 .news-list {
@@ -415,6 +466,32 @@ img {
   display: grid;
   grid-template-columns: 2fr 1fr 1.1fr;
   gap: 24px;
+}
+
+.footer-grid-compact {
+  grid-template-columns: 1fr auto;
+  align-items: center;
+}
+
+.footer-brand p {
+  margin: 2px 0 0;
+  font-size: 13px;
+}
+
+.footer-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  font-size: 14px;
+  font-weight: 650;
+}
+
+.footer-links a {
+  color: var(--muted);
+}
+
+.footer-links a:hover {
+  color: var(--accent);
 }
 
 .footer-grid strong {


### PR DESCRIPTION
A. Merge Selected Publications and Spotlight Projects into a single
   Highlighted Work section, sourced from _data/projects.yml. Each card
   now carries a Paper link (when known) and a Code link. Eliminates the
   prior duplication where DeepAgent / CipherChat / PsychoBench / MAD
   appeared in both sections.

B. Reorder homepage: Hero -> About -> News -> Highlighted Work ->
   Research Areas. News is moved up to surface recent activity.

C. Replace random red/green/blue venue tags with semantic tones:
   conf (solid blue), oral (gold with star), preprint (outlined),
   workshop (gray). Updates projects.yml tone values to match.

E. Render the Service line as venue chips (Nature, Nature MI, NeurIPS,
   ICML, ACL) so the reviewer credentials read more like badges than
   prose, lifting visual weight in the About section.

F. Remove unused jekyll-theme-cayman from _config.yml; the site is
   fully styled by main.scss.

G. Simplify footer to a single row (name + copyright on the left,
   contact / Scholar / GitHub / X links on the right), eliminating the
   role-description duplication with the hero.

Also: lazy-load the shields.io stars badges and shorten the badge label, reducing CLS impact.