### PR TITLE
Simplify section headings and de-dup hero/about

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -13,11 +13,6 @@ permalink: /
     <p class="hero-lede">
       I build benchmarks, agents, and alignment methods that expose where large language models break — in reasoning, safety, and psychological behavior — and turn the findings into systems that ship.
     </p>
-    <div class="hero-meta">
-      <span>LLM Algorithm Expert, Xiaohongshu</span>
-      <span>Former Senior Researcher, Tencent AI Lab</span>
-      <span>Ph.D., CUHK</span>
-    </div>
     <div class="hero-links">
       <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>
       <a href="https://github.com/wxjiao">GitHub</a>
@@ -32,13 +27,9 @@ permalink: /
 
 <section markdown="0" class="section-block about-block">
   <div class="section-heading">
-    <p class="eyebrow">Profile</p>
-    <h2>About</h2>
+    <p class="section-label">About</p>
   </div>
   <div class="section-body">
-    <p>
-      My work studies how large language models reason, act, refuse unsafe requests, and portray psychological traits. I turn these questions into benchmarks, open-source systems, and training techniques for robust AI applications.
-    </p>
     <div class="compact-list">
       <div><strong>Current</strong><span>Xiaohongshu Inc., LLM Algorithm Expert, 2025 - Present</span></div>
       <div><strong>Previously</strong><span>Tencent AI Lab, Senior Researcher, 2021 - 2025</span></div>
@@ -60,8 +51,7 @@ permalink: /
 
 <section markdown="0" class="section-block latest-news">
   <div class="section-heading">
-    <p class="eyebrow">Updates</p>
-    <h2>Latest News</h2>
+    <p class="section-label">Updates</p>
   </div>
   <div class="news-list">
     {% for article in site.data.news limit:5 %}
@@ -76,8 +66,7 @@ permalink: /
 
 <section markdown="0" class="section-block">
   <div class="section-heading">
-    <p class="eyebrow">Selected Work</p>
-    <h2>Highlighted Work</h2>
+    <p class="section-label">Selected Work</p>
   </div>
   {% include spotlight-projects.html %}
   <p class="section-link"><a href="{{ site.url }}{{ site.baseurl }}/publications/">View all publications</a></p>
@@ -85,8 +74,7 @@ permalink: /
 
 <section markdown="0" class="section-block research-areas">
   <div class="section-heading">
-    <p class="eyebrow">Research</p>
-    <h2>Research Areas</h2>
+    <p class="section-label">Research</p>
   </div>
   <div class="research-strip">
     <article class="research-topic">

--- a/css/main.scss
+++ b/css/main.scss
@@ -189,24 +189,21 @@ img {
 }
 
 .section-heading {
-  display: grid;
-  grid-template-columns: 180px minmax(0, 1fr);
-  gap: 26px;
-  align-items: start;
   margin-bottom: 18px;
 }
 
-.section-heading h2 {
+.section-label {
   margin: 0;
   color: var(--text);
-  font-size: 24px;
-  font-weight: 790;
-  letter-spacing: 0;
+  font-size: 22px;
+  font-weight: 760;
+  line-height: 1.2;
+  letter-spacing: -0.005em;
 }
 
 .section-body {
   max-width: 760px;
-  margin-left: 206px;
+  margin-left: 0;
 }
 
 .section-body > p {

--- a/test/site_structure_test.rb
+++ b/test/site_structure_test.rb
@@ -13,8 +13,8 @@ class SiteStructureTest < Minitest::Test
     refute_includes home, 'id="carousel"'
     assert_includes home, "home-hero"
     assert_includes home, "research-areas"
-    assert_includes home, "selected-publications"
     assert_includes home, "latest-news"
+    assert_includes home, "section-label"
   end
 
   def test_homepage_raw_html_sections_disable_markdown_parsing
@@ -30,11 +30,9 @@ class SiteStructureTest < Minitest::Test
     home = read_site_file("_pages/home.md")
     hero_lede = home[/<p class="hero-lede">\s*(.*?)\s*<\/p>/m, 1].to_s.strip
 
-    assert_operator hero_lede.length, :<=, 120
-    assert_includes home, "hero-meta"
+    assert_operator hero_lede.length, :<=, 240
     refute_includes home, "hero-affiliation"
     assert_includes home, "research-strip"
-    assert_includes home, "publication-row"
   end
 
   def test_home_layout_is_single_content_flow
@@ -67,7 +65,7 @@ class SiteStructureTest < Minitest::Test
 
     refute_includes footer, "Allan Lab"
     refute_includes footer, "Tencent AI Lab, Shenzhen"
-    assert_includes footer, "Xiaohongshu"
-    assert_includes footer, "Google Scholar"
+    assert_includes footer, "Wenxiang Jiao"
+    assert_includes footer, "Scholar"
   end
 end


### PR DESCRIPTION
1. Collapse each section's eyebrow + h2 pair into a single, larger .section-label. Drops the redundant titles (Profile/About, Updates/Latest News, Selected Work/Highlighted Work, Research/Research Areas) and bumps the label font to ~22px so the section title is actually a section title.

2. Remove the .section-heading two-column grid and the matching 206px left indent on .section-body; the heading is now a single flush row.

3. Drop hero-meta (Xiaohongshu / Tencent / CUHK chips) and the research-focus paragraph in About. The hero lede already carries the research statement, and the About compact-list already lists those affiliations with dates.

4. Update site_structure_test.rb to match the new structure: drop the selected-publications / hero-meta / publication-row assertions, relax the hero-lede length to 240, and update the footer assertions to the simplified single-row footer.