### PR TITLE
Restyle News page to match home layout

### DIFF
--- a/_pages/allnews.md
+++ b/_pages/allnews.md
@@ -1,14 +1,22 @@
 ---
-title: "News"
-layout: textlay
+title: "Wenxiang Jiao (焦文祥) - News"
+layout: homelay
 excerpt: "Recent research updates, publications, talks, and project news from Wenxiang Jiao."
 sitemap: false
 permalink: /allnews.html
 ---
 
-# News
+<section markdown="0" class="page-header">
+  <h1>News</h1>
+</section>
 
-{% for article in site.data.news %}
-<p>{{ article.date }} <br>
-<em>{{ article.headline }}</em></p>
-{% endfor %}
+<section markdown="0" class="section-block">
+  <div class="news-list">
+    {% for article in site.data.news %}
+    <article class="news-item">
+      <time>{{ article.date }}</time>
+      <p>{{ article.headline }}</p>
+    </article>
+    {% endfor %}
+  </div>
+</section>

--- a/css/main.scss
+++ b/css/main.scss
@@ -188,6 +188,20 @@ img {
   border-bottom: 1px solid var(--line);
 }
 
+.page-header {
+  padding: 48px 0 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.page-header h1 {
+  margin: 0;
+  color: var(--text);
+  font-size: 38px;
+  line-height: 1.1;
+  font-weight: 820;
+  letter-spacing: -0.005em;
+}
+
 .section-heading {
   margin-bottom: 18px;
 }


### PR DESCRIPTION
Switch /allnews.html to the homelay layout and render news items with the same .news-list / .news-item classes used on the homepage Updates section. Adds a .page-header style for the page title.