### PR TITLE
Restyle Research page to home layout and expand each theme

### DIFF
--- a/_pages/research.md
+++ b/_pages/research.md
@@ -1,49 +1,214 @@
 ---
 title: "Wenxiang Jiao (焦文祥) - Research"
-layout: textlay
+layout: homelay
 excerpt: "Research directions of Wenxiang Jiao: LLM agents, reasoning, safety, and psychology."
 sitemap: false
 permalink: /research/
 ---
 
-# Research
+<section markdown="0" class="page-header">
+  <h1>Research</h1>
+</section>
 
-My work studies how large language models reason, act, refuse unsafe requests, and portray psychological traits. I turn these questions into benchmarks, open-source systems, and training techniques for more reliable AI applications.
+<section markdown="0" class="section-block">
+  <div class="section-body">
+    <p>
+      My work studies how large language models reason, act, refuse unsafe requests, and portray psychological traits. I turn these questions into benchmarks, open-source systems, and training techniques for more reliable AI applications.
+    </p>
+  </div>
+</section>
 
-Four directions currently drive most of my research:
+<section markdown="0" class="section-block">
+  <div class="section-heading">
+    <p class="section-label">General Agents</p>
+  </div>
+  <div class="section-body">
+    <p>Multimodal, tool-using, and collaborative agents for complex, long-horizon tasks.</p>
+  </div>
+  <div class="publication-list">
+    <article class="publication-row">
+      <div class="publication-meta">ArXiv 2026</div>
+      <div class="publication-main">
+        <h3>MuSEAgent: A Multimodal Reasoning Agent with Stateful Experiences</h3>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2603.27813">Paper</a>
+          <a href="https://github.com/DeepExperience/MuSEAgent">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">ArXiv 2026</div>
+      <div class="publication-main">
+        <h3>MMSkills: Towards Multimodal Skills for General Visual Agents</h3>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2605.13527">Paper</a>
+          <a href="https://github.com/DeepExperience/MMSkills">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">WWW 2026</div>
+      <div class="publication-main">
+        <h3>DeepAgent: A General Reasoning Agent with Scalable Toolsets</h3>
+        <p>A reasoning agent capable of tackling general tasks by searching for and using the appropriate tools from over 16,000 RapidAPIs in an end-to-end agentic reasoning process.</p>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2510.21618">Paper</a>
+          <a href="https://github.com/DeepExperience/DeepAgent">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">ArXiv 2026</div>
+      <div class="publication-main">
+        <h3>OmniGAIA</h3>
+        <p>A benchmark for evaluating omni-modal general AI assistants.</p>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2602.22897">Paper</a>
+          <a href="https://github.com/RUC-NLPIR/OmniGAIA">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">EMNLP 2024</div>
+      <div class="publication-main">
+        <h3>Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate</h3>
+        <p>The Multi-Agent Debate (MAD) framework addresses the Degeneration-of-Thought problem and explores divergent chains of thought through structured agent interaction.</p>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2305.19118">Paper</a>
+          <a href="https://github.com/Skytliang/Multi-Agents-Debate">Code</a>
+        </div>
+      </div>
+    </article>
+  </div>
+</section>
 
----
+<section markdown="0" class="section-block">
+  <div class="section-heading">
+    <p class="section-label">LLM Reasoning</p>
+  </div>
+  <div class="section-body">
+    <p>Mathematical, reflective, and efficient long-chain reasoning.</p>
+  </div>
+  <div class="publication-list">
+    <article class="publication-row">
+      <div class="publication-meta">ICLR 2026</div>
+      <div class="publication-main">
+        <h3>REA-RL</h3>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">ICLR 2026</div>
+      <div class="publication-main">
+        <h3>DeepCompress</h3>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">EMNLP 2024</div>
+      <div class="publication-main">
+        <h3>Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate</h3>
+        <p>Defines the Degeneration-of-Thought problem in self-reflection and addresses it with multi-agent debate over divergent chains of thought.</p>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2305.19118">Paper</a>
+          <a href="https://github.com/Skytliang/Multi-Agents-Debate">Code</a>
+        </div>
+      </div>
+    </article>
+  </div>
+</section>
 
-## General Agents
+<section markdown="0" class="section-block">
+  <div class="section-heading">
+    <p class="section-label">LLM Safety</p>
+  </div>
+  <div class="section-body">
+    <p>Risk awareness, jailbreak robustness, multilingual safety, and refusal behavior.</p>
+  </div>
+  <div class="publication-list">
+    <article class="publication-row">
+      <div class="publication-meta">NeurIPS 2025 D&amp;B</div>
+      <div class="publication-main">
+        <h3>Towards Evaluating Proactive Risk Awareness of Multimodal Language Models</h3>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2505.17455">Paper</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">ACL 2025</div>
+      <div class="publication-main">
+        <h3>Refuse Whenever You Feel Unsafe: Improving Safety in LLMs via Decoupled Refusal Training (DeRTa)</h3>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2407.09121">Paper</a>
+          <a href="https://github.com/RobustNLP/DeRTa">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">ACL 2025 (Findings)</div>
+      <div class="publication-main">
+        <h3>Chain-of-Jailbreak Attack for Image Generation Models via Editing Step by Step</h3>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2410.03869">Paper</a>
+          <a href="https://github.com/Jarviswang94/Chain-of-Jailbreak">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">ICLR 2024</div>
+      <div class="publication-main">
+        <h3>GPT-4 Is Too Smart To Be Safe: Stealthy Chat with LLMs via Cipher</h3>
+        <p>CipherChat examines whether safety alignment generalizes to non-natural languages such as ciphers; GPT-4 understands ciphers well enough to produce unsafe outputs.</p>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2308.06463">Paper</a>
+          <a href="https://llmcipherchat.github.io/">Project</a>
+        </div>
+      </div>
+    </article>
+  </div>
+</section>
 
-Building agents that perceive multiple modalities, use tools at scale, and collaborate with other agents to solve complex, long-horizon tasks.
+<section markdown="0" class="section-block">
+  <div class="section-heading">
+    <p class="section-label">LLM Personality</p>
+  </div>
+  <div class="section-body">
+    <p>Emotion, personality, and psychological portrayals in conversational AI.</p>
+  </div>
+  <div class="publication-list">
+    <article class="publication-row">
+      <div class="publication-meta">ICLR 2024 Oral</div>
+      <div class="publication-main">
+        <h3>On the Humanity of Conversational AI: Evaluating the Psychological Portrayal of LLMs</h3>
+        <p>PPBench evaluates diverse psychological aspects of LLMs, including personality traits, interpersonal relationships, motivational tests, and emotional abilities.</p>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2310.01386">Paper</a>
+          <a href="https://github.com/CUHK-ARISE/PsychoBench">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">NeurIPS 2024</div>
+      <div class="publication-main">
+        <h3>Emotionally Numb or Empathetic? Evaluating How LLMs Feel using EmotionBench</h3>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2308.03656">Paper</a>
+          <a href="https://github.com/CUHK-ARISE/EmotionBench">Code</a>
+        </div>
+      </div>
+    </article>
+    <article class="publication-row">
+      <div class="publication-meta">Preprint</div>
+      <div class="publication-main">
+        <h3>ChatGPT an ENFJ, Bard an ISTJ: Empirical Study on Personalities of Large Language Models</h3>
+        <div class="inline-links">
+          <a href="https://arxiv.org/abs/2305.19926">Paper</a>
+          <a href="https://github.com/cuhk-arise/llmpersonality">Code</a>
+        </div>
+      </div>
+    </article>
+  </div>
+</section>
 
-- **DeepAgent** — a general reasoning agent that searches and composes tools from large-scale toolsets ([WWW 2026](https://arxiv.org/abs/2510.21618), [code](https://github.com/DeepExperience/DeepAgent)).
-- **OmniGAIA** — a benchmark for omni-modal general AI assistants.
-- **Multi-Agent Debate (MAD)** — eliciting divergent reasoning through structured agent interaction ([EMNLP 2024](https://arxiv.org/abs/2305.19118), [code](https://github.com/Skytliang/Multi-Agents-Debate)).
-
-## LLM Reasoning
-
-Pushing the frontier of mathematical, reflective, and long-chain reasoning while keeping inference efficient.
-
-- **REA-RL** — reinforcement learning recipes for reasoning-efficient LLMs (ICLR 2026).
-- **DeepCompress** — compressing long chains of thought without losing accuracy (ICLR 2026).
-
-## LLM Safety
-
-Risk awareness, jailbreak robustness, multilingual safety, and refusal behavior.
-
-- **CipherChat** — studying how safety alignment generalizes (or fails) on cipher-based non-natural languages ([ICLR 2024](https://arxiv.org/abs/2308.06463), [project](https://llmcipherchat.github.io/)).
-- **DeRTa** — improving refusal training so models decline unsafe requests without over-refusing benign ones.
-
-## LLM Personality
-
-Treating conversational AI as a subject of psychological measurement: emotion, personality, relationships, and motivations.
-
-- **PsychoBench / PPBench** — evaluating the psychological portrayal of LLMs ([ICLR 2024 Oral](https://arxiv.org/abs/2310.01386), [code](https://github.com/CUHK-ARISE/PsychoBench)).
-- **EmotionBench** — measuring how LLMs respond under emotionally charged scenarios.
-- **Fints** — fine-grained interpretation of LLMs' affective and personality traits.
-
----
-
-For a chronological list of all papers, see [Publications]({{ site.url }}{{ site.baseurl }}/publications/) or my [Google Scholar](https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate) page.
+<section markdown="0" class="section-block">
+  <p class="section-link">For the chronological list of all papers, see <a href="{{ site.url }}{{ site.baseurl }}/publications/">Publications</a> or my <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a> page.</p>
+</section>


### PR DESCRIPTION
Switch /research/ from textlay to homelay so it uses the same container, section-label heading, and publication-row card styles as the homepage. Replace the markdown bullet list per theme with a card list driven by real entries from publist.yml (plus two new agent papers provided by the user) and the existing projects.yml.

Each theme now lists at least three works:
- General Agents (5): MuSEAgent, MMSkills, DeepAgent, OmniGAIA, MAD
- LLM Reasoning (3): REA-RL, DeepCompress, MAD (divergent CoT angle)
- LLM Safety (4): MPRA (multimodal), DeRTa, Chain-of-Jailbreak, CipherChat
- LLM Personality (3): PsychoBench, EmotionBench, LLM Personality

Entries without a publist description (or with only a placeholder) intentionally show title + venue + links only; nothing fabricated.