### PR TITLE
Expand OmniGAIA + add DeepCompress code link

### DIFF
--- a/_data/projects.yml
+++ b/_data/projects.yml
@@ -1,10 +1,10 @@
-- name: OmniGAIA
+- name: "OmniGAIA: Towards Native Omni-Modal AI Agents"
   url: https://github.com/RUC-NLPIR/OmniGAIA
   repo: RUC-NLPIR/OmniGAIA
   venue: ArXiv 2026
   tone: preprint
   paper: https://arxiv.org/abs/2602.22897
-  description: A benchmark for evaluating omni-modal general AI assistants.
+  description: A benchmark and foundation agent for omni-modal AI assistants — multi-hop queries across video, audio, and image, with OmniAtlas trained via hindsight-guided tree exploration and OmniDPO.
 
 - name: DeepAgent
   url: https://github.com/RUC-NLPIR/DeepAgent

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -62,8 +62,8 @@ permalink: /research/
     <article class="publication-row">
       <div class="publication-meta">ArXiv 2026</div>
       <div class="publication-main">
-        <h3>OmniGAIA</h3>
-        <p>A benchmark for evaluating omni-modal general AI assistants.</p>
+        <h3>OmniGAIA: Towards Native Omni-Modal AI Agents</h3>
+        <p>A benchmark and foundation agent for omni-modal AI assistants. OmniGAIA synthesizes multi-hop queries across video, audio, and image via an omni-modal event graph; the accompanying OmniAtlas agent uses active omni-modal perception trained with hindsight-guided tree exploration and OmniDPO.</p>
         <div class="inline-links">
           <a href="https://arxiv.org/abs/2602.22897">Paper</a>
           <a href="https://github.com/RUC-NLPIR/OmniGAIA">Code</a>
@@ -110,6 +110,7 @@ permalink: /research/
         <p>A dual-reward RL framework that classifies problems as Simple or Hard in real time and adaptively shortens or extends Chain-of-Thought, improving both accuracy and token efficiency on challenging math benchmarks.</p>
         <div class="inline-links">
           <a href="https://arxiv.org/abs/2510.27419">Paper</a>
+          <a href="https://github.com/Skytliang/DeepCompress">Code</a>
         </div>
       </div>
     </article>


### PR DESCRIPTION
- OmniGAIA: use the full paper title and a description distilled from the abstract (omni-modal benchmark + OmniAtlas foundation agent, trained with hindsight-guided tree exploration and OmniDPO). Updates both research.md and the projects.yml entry that drives the homepage Highlighted Work card.
- DeepCompress: add the Skytliang/DeepCompress code link on the research page.