### PR TITLE
Update hero/research intro copy and widen research intro

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -11,7 +11,7 @@ permalink: /
     <p class="eyebrow">LLMs · Agents · Reasoning · Safety</p>
     <h1>Wenxiang Jiao <span>焦文祥</span></h1>
     <p class="hero-lede">
-      I build benchmarks, agents, and alignment methods that expose where large language models break — in reasoning, safety, and psychological behavior — and turn the findings into systems that ship.
+      I study where large language models break — in reasoning, agency, safety, and psychological behavior — and turn those findings into benchmarks, agents, and alignment methods for reliable AI systems.
     </p>
     <div class="hero-links">
       <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -10,12 +10,10 @@ permalink: /research/
   <h1>Research</h1>
 </section>
 
-<section markdown="0" class="section-block">
-  <div class="section-body">
-    <p>
-      My work studies how large language models reason, act, refuse unsafe requests, and portray psychological traits. I turn these questions into benchmarks, open-source systems, and training techniques for more reliable AI applications.
-    </p>
-  </div>
+<section markdown="0" class="section-block intro-block">
+  <p class="page-intro">
+    My research studies how large language models reason, act as agents, refuse unsafe requests, and portray psychological traits. I develop benchmarks, open-source systems, and training/alignment methods to diagnose model failures and build more reliable AI applications.
+  </p>
 </section>
 
 <section markdown="0" class="section-block">

--- a/css/main.scss
+++ b/css/main.scss
@@ -202,6 +202,14 @@ img {
   letter-spacing: -0.005em;
 }
 
+.page-intro {
+  margin: 0;
+  max-width: none;
+  color: #2d3a52;
+  font-size: 17px;
+  line-height: 1.6;
+}
+
 .section-heading {
   margin-bottom: 18px;
 }


### PR DESCRIPTION
- Replace home hero lede with the user's new wording.
- Replace research page intro paragraph with the user's new wording.
- Move the research intro out of .section-body (which caps at 760px and left a large right gutter) into a full-width .page-intro paragraph.