### PR TITLE
Consolidate Publications into Research and add cover thumbnails

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,7 +17,6 @@
 		<li><a href="{{ site.url }}{{ site.baseurl }}/publications">Publications</a></li>
 		<li><a href="{{ site.url }}{{ site.baseurl }}/allnews.html">News</a></li>
 		<li><a href="{{ site.url }}{{ site.baseurl }}/team">Team</a></li>
-		<li><a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Scholar</a></li>
 	  </ul>
 	</div>
   </div>

--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -1,68 +1,21 @@
 ---
 title: "Wenxiang Jiao (焦文祥) - Publications"
-layout: gridlay
-excerpt: "Selected and full publication list for Wenxiang Jiao."
+layout: homelay
+excerpt: "Full publication list of Wenxiang Jiao on Google Scholar."
 sitemap: false
 permalink: /publications/
+redirect_to: https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate
 ---
 
+<meta http-equiv="refresh" content="0; url=https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">
+<link rel="canonical" href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">
 
-# Publications
+<section markdown="0" class="page-header">
+  <h1>Publications</h1>
+</section>
 
-## Group highlights
-
-<!--
-#### More resources can be found [here]({{site.url}}{{site.baseurl}}/publication_resources).
--->
-
-#### (For a full list see [below](#full-list) or go to [Google Scholar](https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate))
-
-{% assign number_printed = 0 %}
-{% for publi in site.data.publist %}
-
-{% assign even_odd = number_printed | modulo: 2 %}
-{% if publi.highlight == 1 %}
-
-{% if even_odd == 0 %}
-<div class="row">
-{% endif %}
-
-<div class="col-sm-6 clearfix">
- <div class="well">
-  <pubtit>{{ publi.title }}</pubtit>
-  <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/{{ publi.image }}" class="img-responsive" width="33%" style="float: left" />
-  <p>{{ publi.description }}</p>
-  <p><em>{{ publi.authors }}</em></p>
-  <span><strong><a href="{{ publi.link.url }}">{{ publi.link.display }}</a></strong> &nbsp; </span>
-  <span><strong><a href="{{ publi.codelink.url }}">{{ publi.codelink.display }}</a></strong> &nbsp; </span>
-  <span><strong><a href="{{ publi.medialink.url }}">{{ publi.medialink.display }}</a></strong> &nbsp; </span>
-  <p class="text-danger"><strong> {{ publi.news1 }}</strong></p>
-  <p> {{ publi.news2 }}</p>
- </div>
-</div>
-
-{% assign number_printed = number_printed | plus: 1 %}
-
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-{% endif %}
-{% endfor %}
-
-{% assign even_odd = number_printed | modulo: 2 %}
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-<p> &nbsp; </p>
-
-
-## Full List
-
-{% for publi in site.data.publist %}
-
-  {{ publi.title }} <br />
-  <em>{{ publi.authors }} </em><br /><a href="{{ publi.link.url }}">{{ publi.link.display }}</a>
-
-{% endfor %}
+<section markdown="0" class="section-block intro-block">
+  <p class="page-intro">
+    The full list of publications is maintained on <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a>. Redirecting you there now &mdash; if your browser does not redirect automatically, follow the link.
+  </p>
+</section>

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -25,8 +25,11 @@ permalink: /research/
   </div>
   <div class="publication-list">
     <article class="publication-row">
-      <div class="publication-meta">ArXiv 2026</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">ArXiv 2026</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ArXiv 2026</span>
         <h3>MuSEAgent: A Multimodal Reasoning Agent with Stateful Experiences</h3>
         <p>Abstracts interaction data into atomic decision experiences via hindsight reasoning, then retrieves them at inference through policy-driven wide- and deep-search strategies, improving fine-grained visual perception and multimodal reasoning over trajectory-level retrieval baselines.</p>
         <div class="inline-links">
@@ -36,8 +39,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">ArXiv 2026</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">ArXiv 2026</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ArXiv 2026</span>
         <h3>MMSkills: Towards Multimodal Skills for General Visual Agents</h3>
         <p>Represents reusable multimodal procedures as compact, state-conditioned skill packages — a textual procedure paired with runtime state cards and multi-view keyframes — generated from public trajectories and consulted by a branch-loaded skill agent at runtime.</p>
         <div class="inline-links">
@@ -47,8 +53,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">WWW 2026</div>
+      <div class="publication-thumb">
+        <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_deepagent.png" alt="DeepAgent cover" loading="lazy">
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">WWW 2026</span>
         <h3>DeepAgent: A General Reasoning Agent with Scalable Toolsets</h3>
         <p>A reasoning agent capable of tackling general tasks by searching for and using the appropriate tools from over 16,000 RapidAPIs in an end-to-end agentic reasoning process.</p>
         <div class="inline-links">
@@ -58,8 +67,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">ArXiv 2026</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">ArXiv 2026</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ArXiv 2026</span>
         <h3>OmniGAIA: Towards Native Omni-Modal AI Agents</h3>
         <p>A benchmark and foundation agent for omni-modal AI assistants. OmniGAIA synthesizes multi-hop queries across video, audio, and image via an omni-modal event graph; the accompanying OmniAtlas agent uses active omni-modal perception trained with hindsight-guided tree exploration and OmniDPO.</p>
         <div class="inline-links">
@@ -69,8 +81,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">EMNLP 2024</div>
+      <div class="publication-thumb">
+        <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_mad.png" alt="Multi-Agent Debate cover" loading="lazy">
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">EMNLP 2024</span>
         <h3>Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate</h3>
         <p>The Multi-Agent Debate (MAD) framework addresses the Degeneration-of-Thought problem and explores divergent chains of thought through structured agent interaction.</p>
         <div class="inline-links">
@@ -91,8 +106,11 @@ permalink: /research/
   </div>
   <div class="publication-list">
     <article class="publication-row">
-      <div class="publication-meta">ICLR 2026</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">ICLR 2026</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ICLR 2026</span>
         <h3>REA-RL: Reflection-Aware Online Reinforcement Learning for Efficient Large Reasoning Models</h3>
         <p>Tackles overthinking in large reasoning models with a small reflection model that enables parallel sampling and sequential revision during online RL, plus a reflection reward that preserves reflection ability — reducing inference cost by ~35% without sacrificing accuracy.</p>
         <div class="inline-links">
@@ -102,8 +120,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">ICLR 2026</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">ICLR 2026</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ICLR 2026</span>
         <h3>DeepCompress: A Dual Reward Strategy for Dynamically Exploring and Compressing Reasoning Chains</h3>
         <p>A dual-reward RL framework that classifies problems as Simple or Hard in real time and adaptively shortens or extends Chain-of-Thought, improving both accuracy and token efficiency on challenging math benchmarks.</p>
         <div class="inline-links">
@@ -113,8 +134,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">EMNLP 2024</div>
+      <div class="publication-thumb">
+        <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_mad.png" alt="Multi-Agent Debate cover" loading="lazy">
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">EMNLP 2024</span>
         <h3>Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate</h3>
         <p>Defines the Degeneration-of-Thought problem in self-reflection and addresses it with multi-agent debate over divergent chains of thought.</p>
         <div class="inline-links">
@@ -135,8 +159,11 @@ permalink: /research/
   </div>
   <div class="publication-list">
     <article class="publication-row">
-      <div class="publication-meta">NeurIPS 2025 D&amp;B</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">NeurIPS 2025 D&amp;B</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">NeurIPS 2025 D&amp;B</span>
         <h3>Towards Evaluating Proactive Risk Awareness of Multimodal Language Models</h3>
         <p>PaSBench evaluates proactive safety across 416 multimodal scenarios in five safety-critical domains. Top models such as Gemini-2.5-pro reach 64–71% accuracy but miss 45–55% of risks under repetition — failure analysis traces this to unstable proactive reasoning rather than missing knowledge.</p>
         <div class="inline-links">
@@ -145,8 +172,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">ACL 2025</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">ACL 2025</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ACL 2025</span>
         <h3>Refuse Whenever You Feel Unsafe: Improving Safety in LLMs via Decoupled Refusal Training (DeRTa)</h3>
         <p>Identifies a refusal position bias in safety-tuning data and proposes Decoupled Refusal Training: MLE with a harmful response prefix plus Reinforced Transition Optimization, letting LLaMA-3 and Mistral models refuse at any position throughout a harmful response without hurting performance.</p>
         <div class="inline-links">
@@ -156,8 +186,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">ACL 2025 (Findings)</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">ACL 2025 Findings</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ACL 2025 (Findings)</span>
         <h3>Chain-of-Jailbreak Attack for Image Generation Models via Editing Step by Step</h3>
         <p>Decomposes a malicious image-generation query into innocuous sub-queries and iteratively edits the output; bypasses safeguards on GPT-4V, GPT-4o, and Gemini 1.5/Pro in over 60% of cases. A companion Think Twice Prompting defense blocks more than 95%.</p>
         <div class="inline-links">
@@ -167,8 +200,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">ICLR 2024</div>
+      <div class="publication-thumb">
+        <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_cipherchat.png" alt="CipherChat cover" loading="lazy">
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ICLR 2024</span>
         <h3>GPT-4 Is Too Smart To Be Safe: Stealthy Chat with LLMs via Cipher</h3>
         <p>CipherChat examines whether safety alignment generalizes to non-natural languages such as ciphers; GPT-4 understands ciphers well enough to produce unsafe outputs.</p>
         <div class="inline-links">
@@ -189,8 +225,11 @@ permalink: /research/
   </div>
   <div class="publication-list">
     <article class="publication-row">
-      <div class="publication-meta">ICLR 2024 Oral</div>
+      <div class="publication-thumb">
+        <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_ppbench.png" alt="PsychoBench cover" loading="lazy">
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">ICLR 2024 Oral</span>
         <h3>On the Humanity of Conversational AI: Evaluating the Psychological Portrayal of LLMs</h3>
         <p>PPBench evaluates diverse psychological aspects of LLMs, including personality traits, interpersonal relationships, motivational tests, and emotional abilities.</p>
         <div class="inline-links">
@@ -200,8 +239,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">NeurIPS 2024</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">NeurIPS 2024</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">NeurIPS 2024</span>
         <h3>Apathetic or Empathetic? Evaluating LLMs' Emotional Alignments with Humans</h3>
         <p>Uses emotion appraisal theory to test how LLMs' feelings shift across 400+ situations grouped into 36 factors, benchmarked against responses from 1,200+ human subjects. Models including GPT-4, Mixtral-8x22B, and LLaMA-3.1 respond appropriately in some cases but fail to align with human emotional behavior or connect similar situations.</p>
         <div class="inline-links">
@@ -211,8 +253,11 @@ permalink: /research/
       </div>
     </article>
     <article class="publication-row">
-      <div class="publication-meta">EMNLP 2024</div>
+      <div class="publication-thumb">
+        <div class="publication-thumb-placeholder">EMNLP 2024</div>
+      </div>
       <div class="publication-main">
+        <span class="venue-chip-inline">EMNLP 2024</span>
         <h3>On the Reliability of Psychological Scales on Large Language Models</h3>
         <p>Across 2,500 settings per model on GPT-3.5/4, Gemini-Pro, and LLaMA-3.1, shows that LLMs respond consistently to the Big Five Inventory. Further demonstrates GPT-3.5 can emulate diverse personalities and represent specific population groups when given targeted prompts.</p>
         <div class="inline-links">
@@ -224,5 +269,5 @@ permalink: /research/
 </section>
 
 <section markdown="0" class="section-block">
-  <p class="section-link">For the chronological list of all papers, see <a href="{{ site.url }}{{ site.baseurl }}/publications/">Publications</a> or my <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a> page.</p>
+  <p class="section-link">For the chronological list of all papers, see my <a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">Google Scholar</a> page.</p>
 </section>

--- a/css/main.scss
+++ b/css/main.scss
@@ -320,19 +320,59 @@ img {
 
 .publication-row {
   display: grid;
-  grid-template-columns: 112px minmax(0, 1fr);
-  gap: 20px;
+  grid-template-columns: 120px minmax(0, 1fr);
+  gap: 22px;
   padding: 18px 0;
   border: 0;
   border-bottom: 1px solid var(--line);
   border-radius: 0;
+  align-items: start;
 }
 
-.publication-meta {
-  color: var(--accent);
+.publication-thumb {
+  position: relative;
+  width: 120px;
+  height: 120px;
+  border-radius: 10px;
+  overflow: hidden;
+  border: 1px solid var(--line);
+  background: var(--soft);
+}
+
+.publication-thumb img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.publication-thumb-placeholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px;
+  background: linear-gradient(135deg, #edf2fb 0%, #dbe7f7 100%);
+  color: var(--accent-strong);
   font-size: 12px;
   font-weight: 800;
-  line-height: 1.45;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  text-align: center;
+  line-height: 1.25;
+}
+
+.publication-main .venue-chip-inline {
+  display: inline-block;
+  margin-bottom: 8px;
+  padding: 3px 9px;
+  background: #eff6ff;
+  color: #1d4ed8;
+  font-size: 11px;
+  font-weight: 800;
+  border-radius: 999px;
+  letter-spacing: 0.02em;
 }
 
 .publication-row .inline-links {


### PR DESCRIPTION
- Remove Scholar from the top nav (still in hero + footer).
- Convert /publications/ to a Google Scholar redirect page: drop the highlights + full-list rendering, use a meta refresh and a short fallback message. Nav link still says Publications.
- Redesign .publication-row for a 120 px square thumbnail on the left, with venue moved into the content column as a pill chip. Add .publication-thumb-placeholder for entries that do not have a real cover image yet.
- Update the 15 entries on /research/ to use the new layout: real covers for DeepAgent, MAD (x2), CipherChat, and PsychoBench; gradient placeholders for the remaining 10 entries that have no cover yet.

When new cover images are added under images/pubpic/, just swap the placeholder div for an <img> tag in the corresponding entry.