### PR TITLE
Polish Research cards and trim home Publications link

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -69,7 +69,6 @@ permalink: /
     <p class="section-label">Selected Work</p>
   </div>
   {% include spotlight-projects.html %}
-  <p class="section-link"><a href="https://scholar.google.com/citations?hl=zh-CN&user=CvtODukAAAAJ&view_op=list_works&sortby=pubdate">View all publications on Google Scholar</a></p>
 </section>
 
 <section markdown="0" class="section-block research-areas">

--- a/_pages/research.md
+++ b/_pages/research.md
@@ -26,13 +26,13 @@ permalink: /research/
   <div class="publication-list">
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">ArXiv 2026</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ArXiv 2026</span>
         <h3>MuSEAgent: A Multimodal Reasoning Agent with Stateful Experiences</h3>
         <p>Abstracts interaction data into atomic decision experiences via hindsight reasoning, then retrieves them at inference through policy-driven wide- and deep-search strategies, improving fine-grained visual perception and multimodal reasoning over trajectory-level retrieval baselines.</p>
         <div class="inline-links">
+          <span class="publication-venue">ArXiv 2026</span>
           <a href="https://arxiv.org/abs/2603.27813">Paper</a>
           <a href="https://github.com/DeepExperience/MuSEAgent">Code</a>
         </div>
@@ -40,13 +40,13 @@ permalink: /research/
     </article>
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">ArXiv 2026</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ArXiv 2026</span>
         <h3>MMSkills: Towards Multimodal Skills for General Visual Agents</h3>
         <p>Represents reusable multimodal procedures as compact, state-conditioned skill packages — a textual procedure paired with runtime state cards and multi-view keyframes — generated from public trajectories and consulted by a branch-loaded skill agent at runtime.</p>
         <div class="inline-links">
+          <span class="publication-venue">ArXiv 2026</span>
           <a href="https://arxiv.org/abs/2605.13527">Paper</a>
           <a href="https://github.com/DeepExperience/MMSkills">Code</a>
         </div>
@@ -57,10 +57,10 @@ permalink: /research/
         <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_deepagent.png" alt="DeepAgent cover" loading="lazy">
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">WWW 2026</span>
         <h3>DeepAgent: A General Reasoning Agent with Scalable Toolsets</h3>
         <p>A reasoning agent capable of tackling general tasks by searching for and using the appropriate tools from over 16,000 RapidAPIs in an end-to-end agentic reasoning process.</p>
         <div class="inline-links">
+          <span class="publication-venue">WWW 2026</span>
           <a href="https://arxiv.org/abs/2510.21618">Paper</a>
           <a href="https://github.com/DeepExperience/DeepAgent">Code</a>
         </div>
@@ -68,13 +68,13 @@ permalink: /research/
     </article>
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">ArXiv 2026</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ArXiv 2026</span>
         <h3>OmniGAIA: Towards Native Omni-Modal AI Agents</h3>
         <p>A benchmark and foundation agent for omni-modal AI assistants. OmniGAIA synthesizes multi-hop queries across video, audio, and image via an omni-modal event graph; the accompanying OmniAtlas agent uses active omni-modal perception trained with hindsight-guided tree exploration and OmniDPO.</p>
         <div class="inline-links">
+          <span class="publication-venue">ArXiv 2026</span>
           <a href="https://arxiv.org/abs/2602.22897">Paper</a>
           <a href="https://github.com/RUC-NLPIR/OmniGAIA">Code</a>
         </div>
@@ -85,10 +85,10 @@ permalink: /research/
         <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_mad.png" alt="Multi-Agent Debate cover" loading="lazy">
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">EMNLP 2024</span>
         <h3>Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate</h3>
         <p>The Multi-Agent Debate (MAD) framework addresses the Degeneration-of-Thought problem and explores divergent chains of thought through structured agent interaction.</p>
         <div class="inline-links">
+          <span class="publication-venue">EMNLP 2024</span>
           <a href="https://arxiv.org/abs/2305.19118">Paper</a>
           <a href="https://github.com/Skytliang/Multi-Agents-Debate">Code</a>
         </div>
@@ -107,13 +107,13 @@ permalink: /research/
   <div class="publication-list">
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">ICLR 2026</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ICLR 2026</span>
         <h3>REA-RL: Reflection-Aware Online Reinforcement Learning for Efficient Large Reasoning Models</h3>
         <p>Tackles overthinking in large reasoning models with a small reflection model that enables parallel sampling and sequential revision during online RL, plus a reflection reward that preserves reflection ability — reducing inference cost by ~35% without sacrificing accuracy.</p>
         <div class="inline-links">
+          <span class="publication-venue">ICLR 2026</span>
           <a href="https://arxiv.org/abs/2505.19862">Paper</a>
           <a href="https://github.com/hexuandeng/REA-RL">Code</a>
         </div>
@@ -121,13 +121,13 @@ permalink: /research/
     </article>
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">ICLR 2026</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ICLR 2026</span>
         <h3>DeepCompress: A Dual Reward Strategy for Dynamically Exploring and Compressing Reasoning Chains</h3>
         <p>A dual-reward RL framework that classifies problems as Simple or Hard in real time and adaptively shortens or extends Chain-of-Thought, improving both accuracy and token efficiency on challenging math benchmarks.</p>
         <div class="inline-links">
+          <span class="publication-venue">ICLR 2026</span>
           <a href="https://arxiv.org/abs/2510.27419">Paper</a>
           <a href="https://github.com/Skytliang/DeepCompress">Code</a>
         </div>
@@ -138,10 +138,10 @@ permalink: /research/
         <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_mad.png" alt="Multi-Agent Debate cover" loading="lazy">
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">EMNLP 2024</span>
         <h3>Encouraging Divergent Thinking in Large Language Models through Multi-Agent Debate</h3>
         <p>Defines the Degeneration-of-Thought problem in self-reflection and addresses it with multi-agent debate over divergent chains of thought.</p>
         <div class="inline-links">
+          <span class="publication-venue">EMNLP 2024</span>
           <a href="https://arxiv.org/abs/2305.19118">Paper</a>
           <a href="https://github.com/Skytliang/Multi-Agents-Debate">Code</a>
         </div>
@@ -160,26 +160,26 @@ permalink: /research/
   <div class="publication-list">
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">NeurIPS 2025 D&amp;B</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">NeurIPS 2025 D&amp;B</span>
         <h3>Towards Evaluating Proactive Risk Awareness of Multimodal Language Models</h3>
         <p>PaSBench evaluates proactive safety across 416 multimodal scenarios in five safety-critical domains. Top models such as Gemini-2.5-pro reach 64–71% accuracy but miss 45–55% of risks under repetition — failure analysis traces this to unstable proactive reasoning rather than missing knowledge.</p>
         <div class="inline-links">
+          <span class="publication-venue">NeurIPS 2025 D&amp;B</span>
           <a href="https://arxiv.org/abs/2505.17455">Paper</a>
         </div>
       </div>
     </article>
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">ACL 2025</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ACL 2025</span>
         <h3>Refuse Whenever You Feel Unsafe: Improving Safety in LLMs via Decoupled Refusal Training (DeRTa)</h3>
         <p>Identifies a refusal position bias in safety-tuning data and proposes Decoupled Refusal Training: MLE with a harmful response prefix plus Reinforced Transition Optimization, letting LLaMA-3 and Mistral models refuse at any position throughout a harmful response without hurting performance.</p>
         <div class="inline-links">
+          <span class="publication-venue">ACL 2025</span>
           <a href="https://arxiv.org/abs/2407.09121">Paper</a>
           <a href="https://github.com/RobustNLP/DeRTa">Code</a>
         </div>
@@ -187,13 +187,13 @@ permalink: /research/
     </article>
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">ACL 2025 Findings</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ACL 2025 (Findings)</span>
         <h3>Chain-of-Jailbreak Attack for Image Generation Models via Editing Step by Step</h3>
         <p>Decomposes a malicious image-generation query into innocuous sub-queries and iteratively edits the output; bypasses safeguards on GPT-4V, GPT-4o, and Gemini 1.5/Pro in over 60% of cases. A companion Think Twice Prompting defense blocks more than 95%.</p>
         <div class="inline-links">
+          <span class="publication-venue">ACL 2025 (Findings)</span>
           <a href="https://arxiv.org/abs/2410.03869">Paper</a>
           <a href="https://github.com/Jarviswang94/Chain-of-Jailbreak">Code</a>
         </div>
@@ -204,10 +204,10 @@ permalink: /research/
         <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_cipherchat.png" alt="CipherChat cover" loading="lazy">
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ICLR 2024</span>
         <h3>GPT-4 Is Too Smart To Be Safe: Stealthy Chat with LLMs via Cipher</h3>
         <p>CipherChat examines whether safety alignment generalizes to non-natural languages such as ciphers; GPT-4 understands ciphers well enough to produce unsafe outputs.</p>
         <div class="inline-links">
+          <span class="publication-venue">ICLR 2024</span>
           <a href="https://arxiv.org/abs/2308.06463">Paper</a>
           <a href="https://llmcipherchat.github.io/">Project</a>
         </div>
@@ -229,10 +229,10 @@ permalink: /research/
         <img src="{{ site.url }}{{ site.baseurl }}/images/pubpic/cover_ppbench.png" alt="PsychoBench cover" loading="lazy">
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">ICLR 2024 Oral</span>
         <h3>On the Humanity of Conversational AI: Evaluating the Psychological Portrayal of LLMs</h3>
         <p>PPBench evaluates diverse psychological aspects of LLMs, including personality traits, interpersonal relationships, motivational tests, and emotional abilities.</p>
         <div class="inline-links">
+          <span class="publication-venue">ICLR 2024 Oral</span>
           <a href="https://arxiv.org/abs/2310.01386">Paper</a>
           <a href="https://github.com/CUHK-ARISE/PsychoBench">Code</a>
         </div>
@@ -240,13 +240,13 @@ permalink: /research/
     </article>
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">NeurIPS 2024</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">NeurIPS 2024</span>
         <h3>Apathetic or Empathetic? Evaluating LLMs' Emotional Alignments with Humans</h3>
         <p>Uses emotion appraisal theory to test how LLMs' feelings shift across 400+ situations grouped into 36 factors, benchmarked against responses from 1,200+ human subjects. Models including GPT-4, Mixtral-8x22B, and LLaMA-3.1 respond appropriately in some cases but fail to align with human emotional behavior or connect similar situations.</p>
         <div class="inline-links">
+          <span class="publication-venue">NeurIPS 2024</span>
           <a href="https://arxiv.org/abs/2308.03656">Paper</a>
           <a href="https://github.com/CUHK-ARISE/EmotionBench">Code</a>
         </div>
@@ -254,13 +254,13 @@ permalink: /research/
     </article>
     <article class="publication-row">
       <div class="publication-thumb">
-        <div class="publication-thumb-placeholder">EMNLP 2024</div>
+        <div class="publication-thumb-placeholder"></div>
       </div>
       <div class="publication-main">
-        <span class="venue-chip-inline">EMNLP 2024</span>
         <h3>On the Reliability of Psychological Scales on Large Language Models</h3>
         <p>Across 2,500 settings per model on GPT-3.5/4, Gemini-Pro, and LLaMA-3.1, shows that LLMs respond consistently to the Big Five Inventory. Further demonstrates GPT-3.5 can emulate diverse personalities and represent specific population groups when given targeted prompts.</p>
         <div class="inline-links">
+          <span class="publication-venue">EMNLP 2024</span>
           <a href="https://aclanthology.org/2024.emnlp-main.354/">Paper</a>
         </div>
       </div>

--- a/css/main.scss
+++ b/css/main.scss
@@ -349,29 +349,20 @@ img {
 .publication-thumb-placeholder {
   width: 100%;
   height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 10px;
-  background: linear-gradient(135deg, #edf2fb 0%, #dbe7f7 100%);
-  color: var(--accent-strong);
-  font-size: 12px;
-  font-weight: 800;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  text-align: center;
-  line-height: 1.25;
+  background: linear-gradient(135deg, #ece4f5 0%, #c9b8e3 100%);
 }
 
-.publication-main .venue-chip-inline {
-  display: inline-block;
-  margin-bottom: 8px;
-  padding: 3px 9px;
-  background: #eff6ff;
-  color: #1d4ed8;
-  font-size: 11px;
+.inline-links .publication-venue {
+  display: inline-flex;
+  align-items: center;
+  min-height: 32px;
+  padding: 5px 11px;
+  border: 1px solid #dcd1ee;
+  border-radius: 8px;
+  background: #f6f1fc;
+  color: #5b3a92;
+  font-size: 12px;
   font-weight: 800;
-  border-radius: 999px;
   letter-spacing: 0.02em;
 }
 


### PR DESCRIPTION
- home.md: drop the trailing "View all publications on Google Scholar" link from the Selected Work block (per request to stop surfacing Publications from the homepage).
- research.md: move venue from a separate chip above the title into the bottom action row, alongside Paper / Code, so each card has a single cluster of metadata + links. Clear the text out of every publication-thumb-placeholder; they now render as pure gradient artwork.
- main.scss: restyle .publication-thumb-placeholder as a soft lavender gradient with no text; add .inline-links .publication-venue chip styled in the same lavender family so the venue sits visually with the action buttons.