### PR TITLE
Add visitor footprint map to bottom of homepage

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -98,3 +98,7 @@ permalink: /
     </article>
   </div>
 </section>
+
+<section markdown="0" class="section-block visitor-block">
+  {% include visitor-map.html %}
+</section>


### PR DESCRIPTION
Mount the existing _includes/visitor-map.html as the final section on home.md, after Research Areas. The include is fully self-contained (scoped CSS + JS).