### PR TITLE
Make visitor map resilient under Safari ITP

### DIFF
--- a/_includes/visitor-map.html
+++ b/_includes/visitor-map.html
@@ -148,22 +148,49 @@
   // Step 1: load existing visitor records, then continue.
   // cache: 'no-store' + a cache-busting query param so the count
   // reflects the latest DB state on every page load, instead of
-  // replaying a cached response.
+  // replaying a cached response. Defensive parsing so a non-2xx
+  // response (which Supabase returns as a JSON object, not an array)
+  // doesn't break .length / .forEach downstream — Safari hits this
+  // path more often than Chrome.
   fetch(SUPABASE_URL + '/rest/v1/visitor_locations?select=country,city,lat,lng&_t=' + Date.now(),
         { headers: AUTH_HEADERS, cache: 'no-store' })
-    .then(function (r) { return r.json(); })
-    .catch(function ()  { return []; })
+    .then(function (r) {
+      if (!r.ok) {
+        console.warn('[visitor-map] read failed:', r.status, r.statusText);
+        return [];
+      }
+      return r.json();
+    })
+    .catch(function (e) {
+      console.warn('[visitor-map] read network error:', e);
+      return [];
+    })
     .then(function (visitors) {
-      geolocateAndRender(visitors);
+      geolocateAndRender(Array.isArray(visitors) ? visitors : []);
     });
 
 
   function geolocateAndRender(visitors) {
 
+    // Always render the count first using just the historical data,
+    // so Safari/ITP blocking the ipapi geolocation call doesn't leave
+    // the count stuck on the "..." placeholder.
+    document.getElementById('visitor-count').textContent =
+      visitors.length.toLocaleString();
+
     // Step 2: detect current visitor location via IP
-    fetch('https://ipapi.co/json/')
-      .then(function (r) { return r.json(); })
-      .catch(function ()  { return null; })
+    fetch('https://ipapi.co/json/', { cache: 'no-store' })
+      .then(function (r) {
+        if (!r.ok) {
+          console.warn('[visitor-map] geo lookup failed:', r.status);
+          return null;
+        }
+        return r.json();
+      })
+      .catch(function (e)  {
+        console.warn('[visitor-map] geo network error:', e);
+        return null;
+      })
       .then(function (geo) {
 
         var me = null;


### PR DESCRIPTION
Two defensive changes so the visitor count is never stuck on the "..." placeholder:

1. Render the count immediately from the historical visitor list, before the ipapi.co geolocation call. Safari's Intelligent Tracking Prevention can silently block or stall third-party cross-site fetches; if the ipapi call hangs or fails, the count was previously never assigned.

2. Treat any non-2xx Supabase response as an empty array and log the status. Supabase returns a JSON error object on 401/403, not an array — letting that propagate caused .length and .forEach to throw downstream. Array.isArray() guard added before the count is computed.

Same defensive treatment applied to the ipapi.co fetch.