### PR TITLE
Drop _t= cache-buster that PostgREST rejects

### DIFF
--- a/_includes/visitor-map.html
+++ b/_includes/visitor-map.html
@@ -146,13 +146,14 @@
   };
 
   // Step 1: load existing visitor records, then continue.
-  // cache: 'no-store' + a cache-busting query param so the count
-  // reflects the latest DB state on every page load, instead of
-  // replaying a cached response. Defensive parsing so a non-2xx
-  // response (which Supabase returns as a JSON object, not an array)
-  // doesn't break .length / .forEach downstream — Safari hits this
-  // path more often than Chrome.
-  fetch(SUPABASE_URL + '/rest/v1/visitor_locations?select=country,city,lat,lng&_t=' + Date.now(),
+  // cache: 'no-store' bypasses the browser HTTP cache so the count
+  // reflects the latest DB state on every page load.
+  // (No cache-busting query param: PostgREST treats any unknown
+  // query string as a column filter and would 400 the request.)
+  // Defensive parsing so a non-2xx response (Supabase returns a JSON
+  // object on error, not an array) doesn't break .length / .forEach
+  // downstream.
+  fetch(SUPABASE_URL + '/rest/v1/visitor_locations?select=country,city,lat,lng',
         { headers: AUTH_HEADERS, cache: 'no-store' })
     .then(function (r) {
       if (!r.ok) {


### PR DESCRIPTION
PostgREST parses every query string parameter as either a column filter or a known directive (select, order, limit, ...). The "_t=<timestamp>" cache-buster I added was being interpreted as a column filter on a non-existent column "_t" and the request was being rejected with HTTP 400:

  {"code":"PGRST100",
   "details":"unexpected \"1\" expecting \"not\" or operator..."}

Browser visitors fetch therefore returned an error object that our Array.isArray guard converted to [], so the homepage was rendering "1 visitor" (0 historical + 1 for the current viewer) instead of the real count of 1057.

Keep cache: 'no-store' — that header alone is enough to bypass the HTTP cache.