### PR TITLE
Render the latest 1000 visitor dots, not the oldest

### DIFF
--- a/_includes/visitor-map.html
+++ b/_includes/visitor-map.html
@@ -154,7 +154,10 @@
   //   freezes the moment the table grows past 1000.
   // - Defensive parsing so a non-2xx response (Supabase returns a
   //   JSON object on error, not an array) doesn't break downstream.
-  fetch(SUPABASE_URL + '/rest/v1/visitor_locations?select=country,city,lat,lng',
+  // order=visited_at.desc so the up-to-1000 dots we render are the
+  // most recent visitors, not the oldest ones (PostgREST otherwise
+  // returns rows in physical insertion order).
+  fetch(SUPABASE_URL + '/rest/v1/visitor_locations?select=country,city,lat,lng&order=visited_at.desc',
         {
           headers: {
             'apikey':        SUPABASE_ANON_KEY,


### PR DESCRIPTION
PostgREST returns rows in physical insertion order when no order is specified, so the up-to-1000 dots we draw were always the oldest 1000 visitors — recent visitors were invisible on the map once the table grew past the page size.

Add order=visited_at.desc so the rendered sample is the freshest 1000.