### PR TITLE
Rework team page as photo-less compact list of collaborators & students

### DIFF
--- a/_data/team_members.yml
+++ b/_data/team_members.yml
@@ -1,55 +1,99 @@
-- name: Wenxiang Jiao
-  photo: wxjiao2016.jpeg
-  info: Senior Researcher, Tencent AI Lab
-  hobbies: Fitness, Mobile games
-  number_educ: 2
-  education1: PhD CUHK
-  education2: BS/MS Nanjing-U
+# Schema:
+#   name:         required
+#   role:         short tag rendered top-right (e.g. "PhD student", "Postdoc", "Asst Prof")
+#   affiliation:  current institution, full name
+#   education:    list of strings; rendered on one line, separated by " · "
+#   research:     one-line focus, e.g. "LLM safety, jailbreak robustness"
+#   links:        any subset of { homepage, scholar, github } as URLs
+#   selected_works: list of { title, link } — usually 1–2 entries
+#
+# All fields except `name` are optional; the template skips empty ones.
 
 - name: Hexuan Deng
-  photo: hexuan.jpg
-  info: PhD student, HIT (SZ)
-  number_educ: 1
-  education1: BS Nankai-U
+  role: PhD student
+  affiliation: Harbin Institute of Technology (Shenzhen)
+  education:
+    - BS Nankai University
+  research:
+  links:
+    homepage: https://hexuandeng.github.io/
+    scholar:
+    github:
+  selected_works: []
 
 - name: Youliang Yuan
-  photo: youliang.jpg
-  info: PhD student, CUHK (SZ)
-  number_educ: 2
-  education1: MS Wuhan-U
-  education2: BS Tongji-U
+  role: PhD student
+  affiliation: The Chinese University of Hong Kong (Shenzhen)
+  education:
+    - MS Wuhan University
+    - BS Tongji University
+  research:
+  links:
+    homepage: https://youliangyuan.github.io/
+    scholar:
+    github:
+  selected_works: []
 
 - name: Jinhui Ye
-  photo: jinhui.jpg
-  info: PhD student, HKUST
-  number_educ: 2
-  education1: MS HKUST (GZ)
-  education2: BS SCUT
-  
+  role: PhD student
+  affiliation: Hong Kong University of Science and Technology
+  education:
+    - MS HKUST (Guangzhou)
+    - BS South China University of Technology
+  research:
+  links:
+    homepage: https://jhuiye.com/
+    scholar:
+    github:
+  selected_works: []
+
 - name: Jen-tse Huang
-  photo: jentse.jpeg
-  info: Post-doc, JHU
-  number_educ: 2
-  education1: PhD CUHK
-  education2: BS Peking-U
+  role: Postdoc
+  affiliation: Johns Hopkins University
+  education:
+    - PhD The Chinese University of Hong Kong
+    - BS Peking University
+  research:
+  links:
+    homepage: https://penguinnnnn.github.io/
+    scholar:
+    github:
+  selected_works: []
 
 - name: Wenxuan Wang
-  photo: wenxuan.jpeg
-  info: Assistant Prof, Renmin-U
-  number_educ: 2
-  education1: PhD CUHK
-  education2: BS HUST
+  role: Assistant Professor
+  affiliation: Renmin University of China
+  education:
+    - PhD The Chinese University of Hong Kong
+    - BS Huazhong University of Science and Technology
+  research:
+  links:
+    homepage: https://jarviswang94.github.io/
+    scholar:
+    github:
+  selected_works: []
 
 - name: Yifan Hou
-  photo: Yifan.jpg
-  info: PhD student, ETH Zurich
-  hobbies: Fitness, PC games, Cycling
-  number_educ: 2
-  education1: MS CUHK
-  education2: BS HUST
+  role: PhD student
+  affiliation: ETH Zürich
+  education:
+    - MS The Chinese University of Hong Kong
+    - BS Huazhong University of Science and Technology
+  research:
+  links:
+    homepage: https://yifan-h.github.io/
+    scholar:
+    github:
+  selected_works: []
 
 - name: Jiarui Li
-  photo: jiarui.jpeg
-  info: MS student, CMU
-  number_educ: 1
-  education1: BS CUHK (SZ)
+  role: MS student
+  affiliation: Carnegie Mellon University
+  education:
+    - BS The Chinese University of Hong Kong (Shenzhen)
+  research:
+  links:
+    homepage: https://yiluli.github.io/
+    scholar:
+    github:
+  selected_works: []

--- a/_pages/team.md
+++ b/_pages/team.md
@@ -1,227 +1,44 @@
 ---
-title: "Wenxiang Jiao (焦文祥) - Team"
-layout: gridlay
-excerpt: "Team members, collaborators, and students working with Wenxiang Jiao."
+title: "Wenxiang Jiao (焦文祥) - Collaborators & Students"
+layout: homelay
+excerpt: "Researchers and students Wenxiang Jiao has worked with on LLM agents, reasoning, safety, and psychology."
 sitemap: false
 permalink: /team/
 ---
 
-# Group Members
-{% assign number_printed = 0 %}
-{% for member in site.data.team_members %}
+<section markdown="0" class="page-header">
+  <h1>Collaborators &amp; Students</h1>
+  <p class="page-intro">Researchers and students I've worked with on LLM agents, reasoning, safety, and psychology.</p>
+</section>
 
-{% assign even_odd = number_printed | modulo: 2 %}
-
-{% if even_odd == 0 %}
-<div class="row">
-{% endif %}
-
-<div class="col-sm-6 clearfix">
-  <img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-responsive" width="25%" style="float: left" />
-  <div style="overflow: hidden">
-  <h4>{{ member.name }}</h4>
-  <i>{{ member.info }}</i> <!--<br>email: <{{ member.email }}></i> -->
-  {% if member.hobbies %}
-  Hobbies: {{ member.hobbies}}
-  {% endif %}
-  {% if member.startyear %}
-  Start year: {{ member.startyear}}
-  {% endif %}
-  {% if member.researchinterest %}
-  Research interest: {{ member.researchinterest}}
-  {% endif %}
-
-  <ul style="overflow: hidden">
-  {% if member.number_educ == 1 %}
-  <li> {{ member.education1 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 2 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 3 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  <li> {{ member.education3 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 4 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  <li> {{ member.education3 }} </li>
-  <li> {{ member.education4 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 5 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  <li> {{ member.education3 }} </li>
-  <li> {{ member.education4 }} </li>
-  <li> {{ member.education5 }} </li>
-  {% endif %}
-
-  </ul>
+<section markdown="0" class="section-block">
+  <div class="people-list">
+    {% for m in site.data.team_members %}
+    <article class="person">
+      <header class="person-head">
+        <h3 class="person-name">{{ m.name }}</h3>
+        {% if m.role %}<span class="person-role">{{ m.role }}</span>{% endif %}
+      </header>
+      {% if m.affiliation %}
+      <p class="person-affiliation">{{ m.affiliation }}</p>
+      {% endif %}
+      {% if m.education and m.education.size > 0 %}
+      <p class="person-edu"><span class="person-meta-label">Education</span>{% for e in m.education %}{{ e }}{% unless forloop.last %} · {% endunless %}{% endfor %}</p>
+      {% endif %}
+      {% if m.research and m.research != "" %}
+      <p class="person-research"><span class="person-meta-label">Research</span>{{ m.research }}</p>
+      {% endif %}
+      {% if m.selected_works and m.selected_works.size > 0 %}
+      <p class="person-works"><span class="person-meta-label">Selected</span>{% for w in m.selected_works %}<a href="{{ w.link }}">{{ w.title }}</a>{% unless forloop.last %} · {% endunless %}{% endfor %}</p>
+      {% endif %}
+      {% if m.links.homepage or m.links.scholar or m.links.github %}
+      <p class="person-links inline-links">
+        {% if m.links.homepage %}<a href="{{ m.links.homepage }}">Homepage</a>{% endif %}
+        {% if m.links.scholar %}<a href="{{ m.links.scholar }}">Scholar</a>{% endif %}
+        {% if m.links.github %}<a href="{{ m.links.github }}">GitHub</a>{% endif %}
+      </p>
+      {% endif %}
+    </article>
+    {% endfor %}
   </div>
-</div>
-
-{% assign number_printed = number_printed | plus: 1 %}
-
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-{% endfor %}
-
-{% assign even_odd = number_printed | modulo: 2 %}
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-
-
-
-{% assign number_printed = 0 %}
-{% for member in site.data.students %}
-
-{% assign even_odd = number_printed | modulo: 2 %}
-
-{% if even_odd == 0 %}
-<div class="row">
-{% endif %}
-
-<div class="col-sm-6 clearfix">
-  <img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-responsive" width="25%" style="float: left" />
-  <div style="overflow: hidden">
-  <h4>{{ member.name }}</h4>
-  <i>{{ member.info }} <!-- <br>email: <{{ member.email }}></i> -->
-  <br>Hobbies: {{ member.hobbies}}</i>
-  <ul style="overflow: hidden">
-
-  {% if member.number_educ == 1 %}
-  <li> {{ member.education1 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 2 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 3 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  <li> {{ member.education3 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 4 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  <li> {{ member.education3 }} </li>
-  <li> {{ member.education4 }} </li>
-  {% endif %}
-
-  </ul>
-  </div>
-</div>
-
-{% assign number_printed = number_printed | plus: 1 %}
-
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-{% endfor %}
-
-{% assign even_odd = number_printed | modulo: 2 %}
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-
-
-
-{% assign number_printed = 0 %}
-{% for member in site.data.alumni_members %}
-
-{% assign even_odd = number_printed | modulo: 2 %}
-
-{% if even_odd == 0 %}
-<div class="row">
-{% endif %}
-
-<div class="col-sm-6 clearfix">
-  <img src="{{ site.url }}{{ site.baseurl }}/images/teampic/{{ member.photo }}" class="img-responsive" width="25%" style="float: left" />
-  <h4>{{ member.name }}</h4>
-  <i>{{ member.info }} <!-- <br>email: <{{ member.email }}></i> -->
-  <br>Hobbies: {{ member.hobbies}}</i>
-  <ul style="overflow: hidden">
-
-  {% if member.number_educ == 1 %}
-  <li> {{ member.education1 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 2 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 3 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  <li> {{ member.education3 }} </li>
-  {% endif %}
-
-  {% if member.number_educ == 4 %}
-  <li> {{ member.education1 }} </li>
-  <li> {{ member.education2 }} </li>
-  <li> {{ member.education3 }} </li>
-  <li> {{ member.education4 }} </li>
-  {% endif %}
-
-  </ul>
-</div>
-
-{% assign number_printed = number_printed | plus: 1 %}
-
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-{% endfor %}
-
-{% assign even_odd = number_printed | modulo: 2 %}
-{% if even_odd == 1 %}
-</div>
-{% endif %}
-
-<!-- 
-## Former visitors, BSc/ MSc students
-<div class="row">
-
-<div class="col-sm-4 clearfix">
-<h4>Visitors</h4>
-{% for member in site.data.alumni_visitors %}
-{{ member.name }}
-{% endfor %}
-</div>
-
-<div class="col-sm-4 clearfix">
-<h4>Master students</h4>
-{% for member in site.data.alumni_msc %}
-{{ member.name }}
-{% endfor %}
-</div>
-
-<div class="col-sm-4 clearfix">
-<h4>Bachelor Students</h4>
-{% for member in site.data.alumni_bsc %}
-{{ member.name }}
-{% endfor %}
-</div>
-
-</div>
-
-
-## Administrative Support
-<a href="mailto:paulina.motyka@inf.ethz.ch">Paulina Agata Piotrowska-Motyka</a> is helping us (and other groups) with administration. -->
+</section>

--- a/css/main.scss
+++ b/css/main.scss
@@ -500,6 +500,69 @@ img {
   margin: 0;
 }
 
+.people-list {
+  display: grid;
+  gap: 0;
+  border-top: 1px solid var(--line);
+}
+
+.person {
+  padding: 18px 0 16px;
+  border-bottom: 1px solid var(--line);
+}
+
+.person-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+  margin: 0 0 4px;
+}
+
+.person-name {
+  margin: 0;
+  color: var(--text);
+  font-size: 17px;
+  font-weight: 760;
+  letter-spacing: -0.003em;
+}
+
+.person-role {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.person-affiliation {
+  margin: 0 0 6px;
+  color: var(--text);
+  font-size: 14.5px;
+}
+
+.person p {
+  margin: 2px 0;
+  color: var(--muted);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.person-meta-label {
+  display: inline-block;
+  min-width: 78px;
+  color: var(--text);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+.person-links {
+  margin-top: 6px;
+}
+
 .section-link {
   margin: 18px 0 0;
 }


### PR DESCRIPTION
Drop the old "Allan Lab" photo-grid template and "Group Members" framing. Restructure team_members.yml around role/affiliation/education/research/ links/selected_works, expanding school abbreviations and removing the stale self-entry. Switch the page to the modern homelay + section-block style used by /allnews and /research, and add .people-list styling. Empty fields are hidden by template guards, so research/scholar/github/ selected_works can be filled in over time without further template work.